### PR TITLE
Added shebang and argument to run gc in update_modules.sh.

### DIFF
--- a/update_modules.sh
+++ b/update_modules.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 thumbdir=$(pwd)
 for d in */
 do
@@ -7,5 +9,5 @@ do
     cd "$thumbdir"/"$d"
     git checkout master
     git pull origin master --depth=20
-    #git gc --prune=all
+    [[ $1 = "gc" ]] && git gc --prune=all
 done


### PR DESCRIPTION
Currently adding a gc cycle to the update process requires uncommenting a line in the script. This allows using `./update_modules.sh gc` to trigger the same without the edit.